### PR TITLE
Implemented foreground method. Users can now define the text color of…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-## [1.2.0]
+## [1.2.0] - 2018-04-30
 ### Added
   - Implemented support for setting custom text color with `Foreground` method.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-
+## [1.2.0]
+### Added
+  - Implemented support for setting custom text color with `Foreground` method.
 
 ## [1.1.0] - 2018-04-03
 ### Added

--- a/Enterwell.Clients.Wpf.Notifications/Controls/NotificationMessage.cs
+++ b/Enterwell.Clients.Wpf.Notifications/Controls/NotificationMessage.cs
@@ -132,6 +132,17 @@ namespace Enterwell.Clients.Wpf.Notifications.Controls
             get => (string)GetValue(MessageProperty);
             set => SetValue(MessageProperty, value);
         }
+        /// <summary>
+        /// Gets or sets the brush of text.
+        /// <value>
+        /// The text brush.
+        /// </value>
+        /// </summary>
+        public Brush Foreground
+        {
+            get => (Brush)GetValue(ForegroundProperty);
+            set => SetValue(ForegroundProperty, value);
+        }
 
         /// <summary>
         /// Gets or sets the buttons.
@@ -297,6 +308,9 @@ namespace Enterwell.Clients.Wpf.Notifications.Controls
         public NotificationMessage()
         {
             this.Buttons = new ObservableCollection<object>();
+
+            //Setting the default text color, if not defined by user.
+            this.Foreground = new BrushConverter().ConvertFromString("#DDDDDD") as Brush;
         }
     }
 }

--- a/Enterwell.Clients.Wpf.Notifications/INotificationMessage.cs
+++ b/Enterwell.Clients.Wpf.Notifications/INotificationMessage.cs
@@ -104,5 +104,13 @@ namespace Enterwell.Clients.Wpf.Notifications
         /// The content of the overlay.
         /// </value>
         object OverlayContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the brush of the text.
+        /// </summary>
+        /// <value>
+        /// The text brush.
+        /// </value>
+        Brush Foreground { get; set; }
     }
 }

--- a/Enterwell.Clients.Wpf.Notifications/NotificationMessageBuilder.cs
+++ b/Enterwell.Clients.Wpf.Notifications/NotificationMessageBuilder.cs
@@ -102,6 +102,14 @@ namespace Enterwell.Clients.Wpf.Notifications
         }
 
         /// <summary>
+        /// Sets the text brush.
+        /// </summary>
+        public void SetForeground(Brush brush)
+        {
+            this.Message.Foreground = brush;
+        }
+
+        /// <summary>
         /// Queues the message to manager.
         /// </summary>
         /// <returns>Returns the queued message.</returns>

--- a/Enterwell.Clients.Wpf.Notifications/NotificationMessageBuilderLinq.cs
+++ b/Enterwell.Clients.Wpf.Notifications/NotificationMessageBuilderLinq.cs
@@ -266,5 +266,21 @@ namespace Enterwell.Clients.Wpf.Notifications
 
             return builder;
         }
+
+        /// <summary>
+        /// Sets the foreground brush.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="foregroundBrush">The foreground brush.</param>
+        /// <returns>Returns the noitificaiton message builder.</returns>
+        public static NotificationMessageBuilder Foreground(
+            this NotificationMessageBuilder builder,
+            string foregroundBrush)
+        {
+            var brush = new BrushConverter().ConvertFrom(foregroundBrush) as Brush;
+            builder.SetForeground(brush);
+
+            return builder;
+        }
     }
 }

--- a/Enterwell.Clients.Wpf.Notifications/Themes/Generic.xaml
+++ b/Enterwell.Clients.Wpf.Notifications/Themes/Generic.xaml
@@ -28,7 +28,7 @@
 
     <Style x:Key="NotificationMessageTextStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="VerticalAlignment" Value="Center" />
-        <Setter Property="Foreground" Value="#DDDDDD" />
+        <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:NotificationMessage}}, Path=Foreground}" />
         <Setter Property="TextWrapping" Value="Wrap" />
         <Setter Property="Margin" Value="0,0,8,0" />
     </Style>


### PR DESCRIPTION
This PR is based on #4 question.
Since the background can be changed, it can make a little bit of mess when I want a lighter background.
So I believe that this will be an useful feature.

Small sample...

```
this.Manager
.CreateMessage()
.Accent("#42A5F5")
.Foreground("#4c4c4c")
.Background("#eeeef2")
.HasBadge("Info")
.HasMessage("Update will be installed on next application restart.")
.Dismiss().WithButton("Update now", button => { })
.Dismiss().WithButton("Release notes", button => { })
.Dismiss().WithButton("Later", button => { })
.Queue();
```

And we get this

![sample](https://user-images.githubusercontent.com/23723816/39427477-242590ac-4c84-11e8-8e12-59c0d5e75d02.png)



