### PR TITLE
OnMessageDismissed event trigger unexpectedly

### DIFF
--- a/Enterwell.Clients.Wpf.Notifications/NotificationMessageBuilderLinq.cs
+++ b/Enterwell.Clients.Wpf.Notifications/NotificationMessageBuilderLinq.cs
@@ -231,7 +231,28 @@ namespace Enterwell.Clients.Wpf.Notifications
         {
             return call =>
             {
-                builder.Manager.Dismiss(builder.Message);
+                if (builder.Message is INotificationAnimation animatableMessage)
+                {
+                    var animation = animatableMessage.AnimationOut;
+                    if (animation != null && 
+                        animatableMessage.Animates && 
+                        animatableMessage.AnimatableElement != null && 
+                        animatableMessage.AnimationOutDependencyProperty != null)
+                    {
+                        animation.Completed += (s, a) => 
+                        {
+                            builder.Manager.Dismiss(builder.Message);
+                        };
+                    }
+                    else
+                    {
+                        builder.Manager.Dismiss(builder.Message);
+                    }
+                }
+                else
+                {
+                    builder.Manager.Dismiss(builder.Message);
+                }
                 callback?.Invoke(builder.Message);
             };
         }
@@ -251,7 +272,28 @@ namespace Enterwell.Clients.Wpf.Notifications
         {
             return button =>
             {
-                builder.Manager.Dismiss(builder.Message);
+                if (builder.Message is INotificationAnimation animatableMessage)
+                {
+                    var animation = animatableMessage.AnimationOut;
+                    if (animation != null && 
+                        animatableMessage.Animates && 
+                        animatableMessage.AnimatableElement != null && 
+                        animatableMessage.AnimationOutDependencyProperty != null)
+                    {
+                        animation.Completed += (s, a) => 
+                        {
+                            builder.Manager.Dismiss(builder.Message);
+                        };
+                    }
+                    else
+                    {
+                        builder.Manager.Dismiss(builder.Message);
+                    }
+                }
+                else
+                {
+                    builder.Manager.Dismiss(builder.Message);
+                }
                 callback?.Invoke(button);
             };
         }


### PR DESCRIPTION
OnMessageDismissed event trigger unexpectedly when I set the AnimationOut property with Delay.  For solve this problem, I updated the 'DismissBefore' method with add listener to Animation.Completed event. With this update, OnMessageDimissed event trigger when AnimationOut fully completed